### PR TITLE
Use askpass package for password entry

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Imports:
     curl (>= 4.2),
     dplyr (>= 0.8.3),
     fs (>= 1.3.1),
-    getPass (>= 0.2-2),
+    askpass (>= 1.1),
     here (>= 0.1),
     htmltools (>= 0.3.6),
     httr (>= 1.4.0),

--- a/R/create_credentials.R
+++ b/R/create_credentials.R
@@ -162,7 +162,7 @@ get_password <- function(msg = "Enter the SMTP server password: ") {
 
   # nocov start
 
-  getPass::getPass(msg = msg)
+  askpass::askpass(msg)
 
   # nocov end
 }


### PR DESCRIPTION
See https://github.com/jeroen/askpass#r-for-macos

askpass doesn't require tcltk on native Rgui (non rstudio) on Mac/Windows.