### PR TITLE
Pass arbritary options to curl::send_mail

### DIFF
--- a/R/smtp_send.R
+++ b/R/smtp_send.R
@@ -51,6 +51,7 @@
 #'   call be printed? While the username and password will likely be echoed
 #'   during the exchange, such information is encoded and won't be stored on
 #'   the user's system.
+#' @param ... Other options passed to `curl::send_mail()`
 #'
 #' @examples
 #' # Before sending out an email through
@@ -131,7 +132,8 @@ smtp_send <- function(email,
                       bcc = NULL,
                       credentials = NULL,
                       creds_file = "deprecated",
-                      verbose = FALSE) {
+                      verbose = FALSE,
+                      ...) {
 
   # Verify that the `message` object
   # is of the class `email_message`
@@ -215,7 +217,8 @@ smtp_send <- function(email,
       use_ssl = credentials$use_ssl %||% TRUE,
       verbose = verbose,
       username = credentials$user,
-      password = credentials$password
+      password = credentials$password,
+      ...
     )
 
   # Transmit a message about send success depending on the status code

--- a/man/smtp_send.Rd
+++ b/man/smtp_send.Rd
@@ -13,7 +13,8 @@ smtp_send(
   bcc = NULL,
   credentials = NULL,
   creds_file = "deprecated",
-  verbose = FALSE
+  verbose = FALSE,
+  ...
 )
 }
 \arguments{
@@ -62,6 +63,8 @@ instead.}
 call be printed? While the username and password will likely be echoed
 during the exchange, such information is encoded and won't be stored on
 the user's system.}
+
+\item{...}{Other options passed to \code{curl::send_mail()}}
 }
 \description{
 Send an email message to one or more recipients via an SMTP server. The email


### PR DESCRIPTION
Addresses the same issue as #229 but is more general allowing any argument to be passed to curl::send_mail. My particular use case that is solved by this pull request is to be able to send mail using a local smtp server with a self-signed certificate. 