### PR TITLE
Add support for math in blastula_email rmarkdown format

### DIFF
--- a/R/blastula_email_format.R
+++ b/R/blastula_email_format.R
@@ -32,6 +32,12 @@
 #'   default, this is `TRUE`. The standalone HTML file will have no external
 #'   dependencies, it will use URIs to incorporate the contents of linked
 #'   scripts, stylesheets, images, and videos.
+#' @param math_method Passed to `math_method` in [rmarkdown::html_document()].
+#'   Only method `webtex` is supported at the moment to generate math as svg
+#'   image (default), or png (by specifying a url). See details in
+#'   [rmarkdown::html_document()]. Set to `NULL` to deactivate math processing.
+#'   _Note: Using `webtex` requires a internet connection when rendering the
+#'   document as an external service is used.
 #' @param template The Pandoc template to use for rendering. This is the
 #'   `"blastula"` template by default.
 #' @param includes A named list of additional content to include within the
@@ -59,6 +65,7 @@ blastula_email <- function(content_width = "1000px",
                            dev = "png",
                            smart = TRUE,
                            self_contained = TRUE,
+                           math_method = "webtex",
                            template = "blastula",
                            includes = NULL,
                            keep_md = FALSE,
@@ -70,6 +77,10 @@ blastula_email <- function(content_width = "1000px",
 
   if (template == "blastula") {
     template <- system.file("rmd", "template.html", package = "blastula")
+  }
+
+  if (!is.null(math_method) && math_method != "webtex") {
+    stop("Only 'webtex' method is for now supported when math is activated.")
   }
 
   # Note bash escaping is handled by R Markdown (via shQuote())
@@ -111,7 +122,8 @@ blastula_email <- function(content_width = "1000px",
     self_contained = self_contained,
     theme = "default",
     highlight = "default",
-    mathjax = NULL,
+    math_method = math_method,
+    mathjax = "default",
     template = template,
     extra_dependencies = NULL,
     css = NULL,

--- a/man/blastula_email.Rd
+++ b/man/blastula_email.Rd
@@ -18,6 +18,7 @@ blastula_email(
   dev = "png",
   smart = TRUE,
   self_contained = TRUE,
+  math_method = "webtex",
   template = "blastula",
   includes = NULL,
   keep_md = FALSE,
@@ -70,6 +71,13 @@ dashes, and instances of \code{...} to ellipses. By default, this is \code{TRUE}
 default, this is \code{TRUE}. The standalone HTML file will have no external
 dependencies, it will use URIs to incorporate the contents of linked
 scripts, stylesheets, images, and videos.}
+
+\item{math_method}{Passed to \code{math_method} in \code{\link[rmarkdown:html_document]{rmarkdown::html_document()}}.
+Only method \code{webtex} is supported at the moment to generate math as svg
+image (default), or png (by specifying a url). See details in
+\code{\link[rmarkdown:html_document]{rmarkdown::html_document()}}. Set to \code{NULL} to deactivate math processing.
+_Note: Using \code{webtex} requires a internet connection when rendering the
+document as an external service is used.}
 
 \item{template}{The Pandoc template to use for rendering. This is the
 \code{"blastula"} template by default.}


### PR DESCRIPTION
This is a POC to test how we could support math easily in blastula rmardown fomat following the improved support in **rmarkdown**

This first test is using `webtex` method which allow to use an online service to insert math as SVG (default) or PNG in HTML document. Hopefully self-contained image like SVG or PNG are ok to be included in email. 

Another possible method would be using the [**katex**]() R package https://docs.ropensci.org/katex/index.html that we support through `math_method: r-katex` in **rmarkdown** but this will require a specific CSS file. 

I don't how this CSS would behave in email client etc... This needs to be studied. 

If none of this two solutions are possible for email format, this is harder and needs possibly specific adjustement somehow is possible. 