### PR TITLE
Don't test with now-invalid tz names

### DIFF
--- a/tests/testthat/test-mime.R
+++ b/tests/testthat/test-mime.R
@@ -1,7 +1,6 @@
 test_that("`format_rfc2822_date()` produces valid dates", {
 
-  # Expect properly formatted POSIXct date-times
-  # with varying time zones
+  # Expect properly formatted POSIXct date-times with varying time zones
   format_rfc2822_date(
     ISOdatetime(2019, 6, 15, 20, 18, 00, tz = "Europe/Paris")) %>%
     expect_equal("Sat, 15 Jun 2019 20:18:00 +0200")
@@ -18,21 +17,12 @@ test_that("`format_rfc2822_date()` produces valid dates", {
     ISOdatetime(2019, 6, 15, 20, 18, 00, tz = "GMT0")) %>%
     expect_equal("Sat, 15 Jun 2019 20:18:00 +0000")
 
-  format_rfc2822_date(
-    ISOdatetime(2019, 6, 15, 20, 18, 00, tz = "Iran")) %>%
-    expect_equal("Sat, 15 Jun 2019 20:18:00 +0450")
-
-  format_rfc2822_date(
-    ISOdatetime(2019, 6, 15, 20, 18, 00, tz = "Japan")) %>%
-    expect_equal("Sat, 15 Jun 2019 20:18:00 +0900")
-
   # Expect that day values don't have a leading `0`
   format_rfc2822_date(
     ISOdatetime(2015, 6, 2, 20, 18, 00, tz = "America/Los_Angeles")) %>%
     expect_equal("Tue, 2 Jun 2015 20:18:00 -0700")
 
-  # Expect properly formatted POSIXlt date-times
-  # with varying time zones
+  # Expect properly formatted POSIXlt date-times with varying time zones
   format_rfc2822_date(
     ISOdatetime(2019, 6, 15, 20, 18, 00, tz = "Europe/Paris") %>% as.POSIXlt()
   ) %>%
@@ -53,15 +43,14 @@ test_that("varying formats for recipient lists work as expected", {
 
   # Named vs. unnamed recipients (or some named and some unnamed)
   #   Recipients with Unicode characters and double-quotes in their display names
-  # Single vs. multi recipients
+  # Single vs. multiple recipients
 
   # Create an empty email message
   email <- compose_email()
 
   email_date <- ISOdatetime(2015, 6, 2, 20, 18, 00, tz = "America/Los_Angeles")
 
-  # Test resulting MIME messages with variations
-  # in email address lists
+  # Test resulting MIME messages with variations in email address lists
   generate_rfc2822(
     eml = email,
     date = email_date,


### PR DESCRIPTION
There have been recent test check errors on CRAN stemming from a recent update to the tzdata package. With that update, legacy timezone symlinks were dropped and now only continent/ocean plus city name are acceptable (along with a few backward links like `"GB"` and `"NZ"`). There are a few tests that use the dropped tz representations and those have been removed here. There are still plenty of remaining tests of the `format_rfc2822_date()` function, whose responsibility is to generate MIME-message compliant date/time strings.