### PR TITLE
Fix warning: one argument not used by format '=?utf-8?B?%s?='

### DIFF
--- a/R/mime.R
+++ b/R/mime.R
@@ -511,7 +511,7 @@ header_unstructured <- function(
 
     if (encode_unicode) {
       str <- enc2utf8(str)
-      str <- sprintf("=?utf-8?B?%s?=", base64enc::base64encode(charToRaw(str)), 0)
+      str <- sprintf("=?utf-8?B?%s?=", base64enc::base64encode(charToRaw(str)))
 
     } else {
 


### PR DESCRIPTION
remove argument not used in `sprintf("=?utf-8?B?%s?=", base64enc::base64encode(charToRaw(str)), 0).`
remove
 ```
Warning in sprintf("=?utf-8?B?%s?=", base64enc::base64encode(charToRaw(str)), :
one argument not used by format '=?utf-8?B?%s?='
```
when email is send